### PR TITLE
Make custom log fragment optional (enabled by default); plus some fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 class projects (
   $basedir = '/srv/projects',
   $symlink = [],
-  $projects = {},
+  $projects,
 ) inherits ::projects::params {
 
   file { $basedir:

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -150,7 +150,7 @@ define projects::project (
 
 define project_user (
   $user,
-  $group       = undef
+  $group       = undef,
   $create_user = true,
 ) {
   # If users are from an external directory, never try to create them locally

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -30,6 +30,7 @@ define projects::project (
     group { $title:
       gid     => $gid,
       members => $users,
+      provider=> 'ggroupadd', # Requires pdxcat/group module
     }
 
     $users.each |$u| {
@@ -154,10 +155,11 @@ define project_user (
   $create_user = true,
 ) {
   # If users are from an external directory, never try to create them locally
+  # Group managed with pdxcat/group and "group" resource in projects::project above
   if $create_user {
     create_resources('@user', { $user => {} })
-  }
-  User <| title == $user |> {
-    groups +> $group,
+    User <| title == $user |> {
+      groups +> $group,
+    }
   }
 }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -2,16 +2,16 @@
 #
 # A top level project type.
 define projects::project (
-  $apache = {},
-  $tomcat = {},
-  $mysql = {},
+  $apache        = {},
+  $tomcat        = {},
+  $mysql         = {},
   $apache_common = {},
   $default_vhost = true,
-  $uid = undef,
-  $gid = undef,
-  $users = [],
-  $ensure = undef,
-  $description = ""
+  $uid           = undef,
+  $gid           = undef,
+  $users         = [],
+  $ensure        = undef,
+  $description   = ""
 ) {
 
   # If least one project definition exists for this host, creaste the base structure
@@ -48,19 +48,19 @@ define projects::project (
     }
 
     file { "$::projects::basedir/$title/.ssh":
-      ensure   => 'directory',
-      owner  => $uid,
-      group  => $gid,
-      mode     => '700',
-      seltype  => 'ssh_home_t',
+      ensure  => 'directory',
+      owner   => $uid,
+      group   => $gid,
+      mode    => '700',
+      seltype => 'ssh_home_t',
     }
 
     file { "$::projects::basedir/$title/.settings":
-      ensure   => 'directory',
-      owner  => $uid,
-      group  => $gid,
-      mode     => '775',
-      seltype  => 'httpd_sys_content_t',
+      ensure  => 'directory',
+      owner   => $uid,
+      group   => $gid,
+      mode    => '775',
+      seltype => 'httpd_sys_content_t',
     }
 
     file { [
@@ -75,20 +75,20 @@ define projects::project (
     file { [
            "$::projects::basedir/$title/var",
            ] :
-      ensure => directory,
-      owner  => $uid,
-      group  => $gid,
+      ensure  => directory,
+      owner   => $uid,
+      group   => $gid,
       seltype => 'httpd_sys_rw_content_t',
-      mode   => '0775',
+      mode    => '0775',
     }
 
     file { [
            "$::projects::basedir/$title/lib",
            ] :
-      ensure => directory,
-      owner  => $uid,
-      group  => $gid,
-      mode   => '0775',
+      ensure  => directory,
+      owner   => $uid,
+      group   => $gid,
+      mode    => '0775',
       seltype => 'httpd_sys_content_t',
     }
 
@@ -126,7 +126,7 @@ define projects::project (
   # Create Tomcat services
   if ($tomcat != {}) {
     projects::project::tomcat { $title:
-      ajp_port      => pick($tomcat[ajp_port],'8009')
+      ajp_port => pick($tomcat[ajp_port],'8009')
     }
   }
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -10,6 +10,7 @@ define projects::project (
   $uid           = undef,
   $gid           = undef,
   $users         = [],
+  $create_users  = true,
   $ensure        = undef,
   $description   = ""
 ) {
@@ -33,8 +34,9 @@ define projects::project (
 
     $users.each |$u| {
       project_user { "${title} - user ${u}":
-        user  => $u,
-        group => $title,
+        user        => $u,
+        group       => $title,
+        create_user => $create_users,
       }
     }
 
@@ -148,9 +150,13 @@ define projects::project (
 
 define project_user (
   $user,
-  $group = undef
+  $group       = undef
+  $create_user = true,
 ) {
-  create_resources('@user', { $user => {} })
+  # If users are from an external directory, never try to create them locally
+  if $create_user {
+    create_resources('@user', { $user => {} })
+  }
   User <| title == $user |> {
     groups +> $group,
   }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -31,8 +31,11 @@ define projects::project (
       members => $users,
     }
 
-    project_user { $users:
-      group => $title
+    $users.each |$u| {
+      project_user { "${title} - user ${u}":
+        user  => $u,
+        group => $title,
+      }
     }
 
     file { [
@@ -144,10 +147,11 @@ define projects::project (
 }
 
 define project_user (
+  $user,
   $group = undef
 ) {
-  create_resources('@user', { $title => {} })
-  User <| title == $title |> {
+  create_resources('@user', { $user => {} })
+  User <| title == $user |> {
     groups +> $group,
   }
 }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -150,7 +150,7 @@ define project_user (
   $user,
   $group = undef
 ) {
-  create_resources('@user', { $user => {} })
+  ensure_resources('user', { $user => {} })
   User <| title == $user |> {
     groups +> $group,
   }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -2,17 +2,18 @@
 #
 # A top level project type.
 define projects::project (
-  $apache        = {},
-  $tomcat        = {},
-  $mysql         = {},
-  $apache_common = {},
-  $default_vhost = true,
-  $uid           = undef,
-  $gid           = undef,
-  $users         = [],
-  $create_users  = true,
-  $ensure        = undef,
-  $description   = ""
+  $apache                    = {},
+  $tomcat                    = {},
+  $mysql                     = {},
+  $apache_common             = {},
+  $default_vhost             = true,
+  $uid                       = undef,
+  $gid                       = undef,
+  $users                     = [],
+  $create_users              = true,
+  $force_local_project_group = false,
+  $ensure                    = undef,
+  $description               = ""
 ) {
 
   # If least one project definition exists for this host, creaste the base structure
@@ -28,9 +29,12 @@ define projects::project (
     }
 
     group { $title:
-      gid     => $gid,
-      members => $users,
-      provider=> 'ggroupadd', # Requires pdxcat/group module
+      gid      => $gid,
+      members  => $users,
+      provider => $force_local_project_group ? {
+        true    => 'ggroupadd', # Requires pdxcat/group module
+        default => undef,
+      },
     }
 
     $users.each |$u| {

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -150,7 +150,7 @@ define project_user (
   $user,
   $group = undef
 ) {
-  ensure_resources('user', { $user => {} })
+  create_resources('@user', { $user => {} })
   User <| title == $user |> {
     groups +> $group,
   }

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -210,6 +210,10 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -228,6 +232,10 @@ define projects::project::apache::vhost (
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -253,6 +261,10 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -210,10 +210,6 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
-      #access_log_env_var    => "!forwarded",
-      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -232,10 +228,6 @@ define projects::project::apache::vhost (
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
-      #access_log_env_var    => "!forwarded",
-      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -261,10 +253,6 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
-      #access_log_env_var    => "!forwarded",
-      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -46,7 +46,7 @@ define projects::project::apache (
 
 
   if $apache_common['php'] {
-    ensure_resource('class', '::apache::mod::php', {})
+    include '::apache::mod::php'
     ensure_packages(['php-pdo', 'php-mysql', 'php-mbstring', 'php-snmp'])
   }
 

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -44,7 +44,6 @@ define projects::project::apache (
     }
   }
 
-
   if $apache_common['php'] {
     include '::apache::mod::php'
     ensure_packages(['php-pdo', 'php-mysql', 'php-mbstring', 'php-snmp'])
@@ -211,10 +210,10 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
-      access_log_env_var    => "!forwarded",
-      custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -233,10 +232,10 @@ define projects::project::apache::vhost (
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
-      access_log_env_var    => "!forwarded",
-      custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
@@ -262,10 +261,10 @@ define projects::project::apache::vhost (
       ssl_key               => 
       "${::projects::basedir}/${projectname}/etc/ssl/private/${cert_name}.key",
       serveraliases         => $altnames,
-      access_log_env_var    => "!forwarded",
-      custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-      SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
-      CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
+      #access_log_env_var    => "!forwarded",
+      #custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+      #SetEnvIf X-Forwarded-For \"^.*\\..*\\..*\\..*\" forwarded
+      #CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded",
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -297,7 +297,7 @@ define projects::project::apache::vhost (
 
   if !defined(Firewall["050 accept Apache ${port}"]) {
     firewall { "050 accept Apache ${port}":
-      dport   => $port,
+      dport  => $port,
       proto  => tcp,
       action => accept,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,7 @@
     {"name":"camptocamp-openssl","version_requirement":">= 1.5.1"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.0"},
     {"name":"saz-sudo","version_requirement":">= 3.1.0"}
+    {"name":"pdxcat-group","version_requirement":">= 0.0.2"}
   ]
 }
 


### PR DESCRIPTION
The CustomLog entries don't work for my needs, and are superceded by the use of mod_remoteip.  mod_remoteip also allows (and strongly encourages!) restricting which hosts to trust the X-Forwarded-For header from.
You can use this by doing something like this in your manifest:
```
class { '::apache':
  ...
  # Override default combined log format for mod_remoteip
  log_formats         => { combined => '%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"' },
}
class { '::apache::mod::remoteip':
  proxy_ips => [ '1.2.3.4', '5.6.7.8', ],
}
```
..and then setting `forwarded_custom_log : false` in your projects apache vhost hashes.

Other fixes:
 - Don't allow an empty (or non-existent, possibly due to a typo in your hiera data..) `projects::projects` hash
 - Make `project_user` definitions unique across projects, so that the same usernames can be added to multiple projects on one host
 - Use `include` instead of `ensure_resources` to include php module class, avoiding multiple declaration errors