### PR TITLE
Fix metadata.json file (missing trailing comma).

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     {"name":"puppetlabs-apache","version_requirement":">= 1.5.0"},
     {"name":"camptocamp-openssl","version_requirement":">= 1.5.1"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.0"},
-    {"name":"saz-sudo","version_requirement":">= 3.1.0"}
+    {"name":"saz-sudo","version_requirement":">= 3.1.0"},
     {"name":"pdxcat-group","version_requirement":">= 0.0.2"}
   ]
 }


### PR DESCRIPTION
Ooops, forgot to add comma when adding pdxcat-group dependency to metadata.json file.  Sorry!