### PR TITLE
fix: switch apache::vhost to typed parameters

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -228,7 +228,7 @@ define projects::project::apache::vhost (
       redirect_status       => 'permanent',
       redirect_dest         => $redirect,
       logroot               => "${::projects::basedir}/${projectname}/var/log/httpd",
-      use_optional_includes => "true",
+      use_optional_includes => true,
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
@@ -254,7 +254,7 @@ define projects::project::apache::vhost (
       redirect_status       => 'permanent',
       redirect_dest         => "https://${title}/",
       logroot               => "${::projects::basedir}/${projectname}/var/log/httpd",
-      use_optional_includes => "true",
+      use_optional_includes => true,
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
@@ -273,7 +273,7 @@ define projects::project::apache::vhost (
       docroot               => $full_docroot,
       directories           => $directories,
       logroot               => "${::projects::basedir}/${projectname}/var/log/httpd",
-      use_optional_includes => "true",
+      use_optional_includes => true,
       additional_includes   => 
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -242,7 +242,9 @@ define projects::project::apache::vhost (
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
-      headers               => 'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      headers               => [
+        'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      ],
       *                     => $custom_log_entries,
     }
   }
@@ -261,7 +263,9 @@ define projects::project::apache::vhost (
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
-      headers               => 'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      headers               => [
+        'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      ],
       *                     => $custom_log_entries,
     }
   }
@@ -287,7 +291,9 @@ define projects::project::apache::vhost (
       ip                    => $ip,
       ip_based              => $ip_based,
       add_listen            => false,
-      headers               => 'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      headers               => [
+        'Set Strict-Transport-Security "max-age=63072000; includeSubdomains;"',
+      ],
       php_values            => $php_values,
       *                     => $custom_log_entries,
     }


### PR DESCRIPTION
puppetlabs-apache 8.0.0+ uses type enforcement.